### PR TITLE
Only check callback pointer validity

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -380,7 +380,7 @@ rmw_ret_t
 rmw_client_set_listener_callback(
   rmw_client_t * rmw_client,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * client_handle)
 {
   return rmw_fastrtps_shared_cpp::__rmw_client_set_listener_callback(

--- a/rmw_fastrtps_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_event.cpp
@@ -52,7 +52,7 @@ rmw_ret_t
 rmw_event_set_listener_callback(
   rmw_event_t * rmw_event,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * waitable_handle,
   bool use_previous_events)
 {

--- a/rmw_fastrtps_cpp/src/rmw_guard_condition.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_guard_condition.cpp
@@ -47,7 +47,7 @@ rmw_ret_t
 rmw_guard_condition_set_listener_callback(
   rmw_guard_condition_t * rmw_guard_condition,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * guard_condition_handle,
   bool use_previous_events)
 {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -386,7 +386,7 @@ rmw_ret_t
 rmw_service_set_listener_callback(
   rmw_service_t * rmw_service,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * service_handle)
 {
   return rmw_fastrtps_shared_cpp::__rmw_service_set_listener_callback(

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -172,7 +172,7 @@ rmw_ret_t
 rmw_subscription_set_listener_callback(
   rmw_subscription_t * rmw_subscription,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * subscription_handle)
 {
   return rmw_fastrtps_shared_cpp::__rmw_subscription_set_listener_callback(

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -179,7 +179,7 @@ public:
   // new event from this listener has ocurred
   void
   clientSetExecutorCallback(
-    const void * user_data,
+    void * user_data,
     rmw_listener_callback_t callback,
     const void * client_handle)
   {
@@ -227,7 +227,7 @@ private:
 
   rmw_listener_callback_t listener_callback_{nullptr};
   const void * client_handle_{nullptr};
-  const void * user_data_{nullptr};
+  void * user_data_{nullptr};
   std::mutex listener_callback_mutex_;
   uint64_t unread_count_ = 0;
 };

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -185,13 +185,11 @@ public:
   {
     std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
 
-    if(user_data && client_handle && callback)
-    {
+    if (callback) {
       user_data_ = user_data;
       listener_callback_ = callback;
       client_handle_ = client_handle;
     } else {
-       // Unset callback: If any of the pointers is NULL, do not use callback.
       user_data_ = nullptr;
       listener_callback_ = nullptr;
       client_handle_ = nullptr;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_event_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_event_info.hpp
@@ -70,13 +70,13 @@ public:
   // Provide handlers to perform an action when a
   // new event from this listener has ocurred
   virtual void eventSetExecutorCallback(
-    const void * user_data,
+    void * user_data,
     rmw_listener_callback_t callback,
     const void * waitable_handle,
     bool use_previous_events) = 0;
 
   rmw_listener_callback_t listener_callback_{nullptr};
-  const void * user_data_{nullptr};
+  void * user_data_{nullptr};
   const void * waitable_handle_{nullptr};
   uint64_t unread_events_count_ = 0;
   std::mutex listener_callback_mutex_;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -95,7 +95,7 @@ public:
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void eventSetExecutorCallback(
-    const void * user_data,
+    void * user_data,
     rmw_listener_callback_t callback,
     const void * waitable_handle,
     bool use_previous_events) final;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -300,13 +300,11 @@ public:
   {
     std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
 
-    if(user_data && service_handle && callback)
-    {
+    if (callback) {
       user_data_ = user_data;
       listener_callback_ = callback;
       service_handle_ = service_handle;
     } else {
-       // Unset callback: If any of the pointers is NULL, do not use callback.
       user_data_ = nullptr;
       listener_callback_ = nullptr;
       service_handle_ = nullptr;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -294,7 +294,7 @@ public:
   // new event from this listener has ocurred
   void
   serviceSetExecutorCallback(
-    const void * user_data,
+    void * user_data,
     rmw_listener_callback_t callback,
     const void * service_handle)
   {
@@ -330,7 +330,7 @@ private:
 
   rmw_listener_callback_t listener_callback_{nullptr};
   const void * service_handle_{nullptr};
-  const void * user_data_{nullptr};
+  void * user_data_{nullptr};
   std::mutex listener_callback_mutex_;
   uint64_t unread_count_ = 0;
 };

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -114,7 +114,7 @@ public:
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void eventSetExecutorCallback(
-    const void * user_data,
+    void * user_data,
     rmw_listener_callback_t callback,
     const void * waitable_handle,
     bool use_previous_events) final;
@@ -172,7 +172,7 @@ public:
   // new event from this listener has ocurred
   void
   subcriptionSetExecutorCallback(
-    const void * user_data,
+    void * user_data,
     rmw_listener_callback_t callback,
     const void * subscription_handle)
   {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -178,13 +178,11 @@ public:
   {
     std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
 
-    if(user_data && subscription_handle && callback)
-    {
+    if (callback) {
       user_data_ = user_data;
       listener_callback_ = callback;
       subscription_handle_ = subscription_handle;
     } else {
-      // Unset callback: If any of the pointers is NULL, do not use callback.
       user_data_ = nullptr;
       listener_callback_ = nullptr;
       subscription_handle_ = nullptr;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -397,7 +397,7 @@ rmw_ret_t
 __rmw_subscription_set_listener_callback(
   rmw_subscription_t * rmw_subscription,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * subscription_handle);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
@@ -405,7 +405,7 @@ rmw_ret_t
 __rmw_service_set_listener_callback(
   rmw_service_t * rmw_service,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * service_handle);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
@@ -413,7 +413,7 @@ rmw_ret_t
 __rmw_client_set_listener_callback(
   rmw_client_t * rmw_client,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * client_handle);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
@@ -421,7 +421,7 @@ rmw_ret_t
 __rmw_guard_condition_set_listener_callback(
   rmw_guard_condition_t * rmw_guard_condition,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * guard_condition_handle,
   bool use_previous_events);
 
@@ -430,7 +430,7 @@ rmw_ret_t
 __rmw_event_set_listener_callback(
   rmw_event_t * rmw_event,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * waitable_handle,
   bool use_previous_events);
 

--- a/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
@@ -91,7 +91,7 @@ bool PubListener::hasEvent(rmw_event_type_t event_type) const
 }
 
 void PubListener::eventSetExecutorCallback(
-    const void * user_data,
+    void * user_data,
     rmw_listener_callback_t callback,
     const void * waitable_handle,
     bool use_previous_events)

--- a/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
@@ -98,13 +98,11 @@ void PubListener::eventSetExecutorCallback(
 {
   std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
 
-  if(user_data && waitable_handle && callback)
-  {
+  if (callback) {
     user_data_ = user_data;
     listener_callback_ = callback;
     waitable_handle_ = waitable_handle;
   } else {
-    // Unset callback: If any of the pointers is NULL, do not use callback.
     user_data_ = nullptr;
     listener_callback_ = nullptr;
     waitable_handle_ = nullptr;

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -93,7 +93,7 @@ bool SubListener::hasEvent(rmw_event_type_t event_type) const
 }
 
 void SubListener::eventSetExecutorCallback(
-    const void * user_data,
+    void * user_data,
     rmw_listener_callback_t callback,
     const void * waitable_handle,
     bool use_previous_events)

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -100,13 +100,11 @@ void SubListener::eventSetExecutorCallback(
 {
   std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
 
-  if(user_data && waitable_handle && callback)
-  {
+  if (callback) {
     user_data_ = user_data;
     listener_callback_ = callback;
     waitable_handle_ = waitable_handle;
   } else {
-    // Unset callback: If any of the pointers is NULL, do not use callback.
     user_data_ = nullptr;
     listener_callback_ = nullptr;
     waitable_handle_ = nullptr;

--- a/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
@@ -85,7 +85,7 @@ rmw_ret_t
 __rmw_client_set_listener_callback(
   rmw_client_t * rmw_client,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * client_handle)
 {
   auto custom_client_info = static_cast<CustomClientInfo *>(rmw_client->data);

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -72,7 +72,7 @@ rmw_ret_t
 __rmw_event_set_listener_callback(
   rmw_event_t * rmw_event,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * waitable_handle,
   bool use_previous_events)
 {

--- a/rmw_fastrtps_shared_cpp/src/rmw_guard_condition.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_guard_condition.cpp
@@ -51,7 +51,7 @@ rmw_ret_t
 __rmw_guard_condition_set_listener_callback(
   rmw_guard_condition_t * rmw_guard_condition,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * guard_condition_handle,
   bool use_previous_events)
 {

--- a/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
@@ -98,7 +98,7 @@ rmw_ret_t
 __rmw_service_set_listener_callback(
   rmw_service_t * rmw_service,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * service_handle)
 {
   auto custom_service_info = static_cast<CustomServiceInfo *>(rmw_service->data);

--- a/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
@@ -111,7 +111,7 @@ rmw_ret_t
 __rmw_subscription_set_listener_callback(
   rmw_subscription_t * rmw_subscription,
   rmw_listener_callback_t callback,
-  const void * user_data,
+  void * user_data,
   const void * subscription_handle)
 {
   auto custom_subscriber_info = static_cast<CustomSubscriberInfo *>(rmw_subscription->data);

--- a/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
+++ b/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
@@ -92,7 +92,7 @@ public:
   // new event from this listener has ocurred
   void
   guardConditionSetExecutorCallback(
-    const void * user_data,
+    void * user_data,
     rmw_listener_callback_t callback,
     const void * waitable_handle,
     bool use_previous_events)
@@ -129,7 +129,7 @@ private:
 
   rmw_listener_callback_t listener_callback_{nullptr};
   const void * waitable_handle_{nullptr};
-  const void * user_data_{nullptr};
+  void * user_data_{nullptr};
   std::mutex listener_callback_mutex_;
   uint64_t unread_count_ = 0;
 };

--- a/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
+++ b/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
@@ -99,13 +99,11 @@ public:
   {
     std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
 
-    if(user_data && waitable_handle && callback)
-    {
+    if (callback) {
       user_data_ = user_data;
       listener_callback_ = callback;
       waitable_handle_ = waitable_handle;
     } else {
-      // Unset callback: If any of the pointers is NULL, do not use callback.
       user_data_ = nullptr;
       listener_callback_ = nullptr;
       waitable_handle_ = nullptr;


### PR DESCRIPTION
This is the only item that is used in the RMW layer, while the others are simply forwarded.