### PR TITLE
Rename listener callbacks setters

### DIFF
--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -163,7 +163,7 @@ create_subscription(
   }
 
   if (create_subscription_listener) {
-    info->listener_ = new (std::nothrow) SubListener(info);
+    info->listener_ = new (std::nothrow) SubListener(info, qos_policies->depth);
     if (!info->listener_) {
       RMW_SET_ERROR_MSG("create_subscriber() could not create subscriber listener");
       return nullptr;

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -175,7 +175,7 @@ create_subscription(
     return nullptr;
   }
 
-  info->listener_ = new (std::nothrow) SubListener(info);
+  info->listener_ = new (std::nothrow) SubListener(info, qos_policies->depth);
   if (!info->listener_) {
     RMW_SET_ERROR_MSG("create_subscriber() could not create subscriber listener");
     return nullptr;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -110,11 +110,10 @@ public:
             list_has_data_.store(true);
           }
 
-          // Add the client event to the event queue
-          std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+          std::unique_lock<std::mutex> lock_mutex(on_new_response_m_);
 
-          if(listener_callback_) {
-            listener_callback_(user_data_, 1);
+          if(on_new_response_cb_) {
+            on_new_response_cb_(user_data_, 1);
           } else {
             unread_count_++;
           }
@@ -178,11 +177,11 @@ public:
   // Provide handlers to perform an action when a
   // new event from this listener has ocurred
   void
-  clientSetExecutorCallback(
+  set_on_new_response_callback(
     const void * user_data,
     rmw_event_callback_t callback)
   {
-    std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+    std::unique_lock<std::mutex> lock_mutex(on_new_response_m_);
 
     if (callback) {
       // Push events arrived before setting the the executor callback
@@ -191,10 +190,10 @@ public:
         unread_count_ = 0;
       }
       user_data_ = user_data;
-      listener_callback_ = callback;
+      on_new_response_cb_ = callback;
     } else {
       user_data_ = nullptr;
-      listener_callback_ = nullptr;
+      on_new_response_cb_ = nullptr;
     }
   }
 
@@ -218,9 +217,9 @@ private:
   std::condition_variable * conditionVariable_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
   std::set<eprosima::fastrtps::rtps::GUID_t> publishers_;
 
-  rmw_event_callback_t listener_callback_{nullptr};
+  rmw_event_callback_t on_new_response_cb_{nullptr};
   const void * user_data_{nullptr};
-  std::mutex listener_callback_mutex_;
+  std::mutex on_new_response_m_;
   uint64_t unread_count_ = 0;
 };
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_event_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_event_info.hpp
@@ -69,14 +69,14 @@ public:
 
   // Provide handlers to perform an action when a
   // new event from this listener has ocurred
-  virtual void eventSetExecutorCallback(
+  virtual void set_on_new_event_callback(
     const void * user_data,
     rmw_event_callback_t callback) = 0;
 
-  rmw_event_callback_t listener_callback_{nullptr};
+  rmw_event_callback_t on_new_event_cb_{nullptr};
   const void * user_data_{nullptr};
   uint64_t unread_events_count_ = 0;
-  std::mutex listener_callback_mutex_;
+  std::mutex on_new_event_m_;
 };
 
 class EventListenerInterface::ConditionalScopedLock

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -94,7 +94,7 @@ public:
   hasEvent(rmw_event_type_t event_type) const final;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
-  void eventSetExecutorCallback(
+  void set_on_new_event_callback(
     const void * user_data,
     rmw_event_callback_t callback) final;
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -232,11 +232,10 @@ public:
           list_has_data_.store(true);
         }
 
-        // Add the service to the event queue
-        std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+        std::unique_lock<std::mutex> lock_mutex(on_new_request_m_);
 
-        if(listener_callback_) {
-          listener_callback_(user_data_, 1);
+        if(on_new_request_cb_) {
+          on_new_request_cb_(user_data_, 1);
         } else {
           unread_count_++;
         }
@@ -293,11 +292,11 @@ public:
   // Provide handlers to perform an action when a
   // new event from this listener has ocurred
   void
-  serviceSetExecutorCallback(
+  set_on_new_request_callback(
     const void * user_data,
     rmw_event_callback_t callback)
   {
-    std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+    std::unique_lock<std::mutex> lock_mutex(on_new_request_m_);
 
     if (callback) {
       // Push events arrived before setting the the executor callback
@@ -306,10 +305,10 @@ public:
         unread_count_ = 0;
       }
       user_data_ = user_data;
-      listener_callback_ = callback;
+      on_new_request_cb_ = callback;
     } else {
       user_data_ = nullptr;
-      listener_callback_ = nullptr;
+      on_new_request_cb_ = nullptr;
     }
   }
 
@@ -321,9 +320,9 @@ private:
   std::mutex * conditionMutex_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
   std::condition_variable * conditionVariable_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
 
-  rmw_event_callback_t listener_callback_{nullptr};
+  rmw_event_callback_t on_new_request_cb_{nullptr};
   const void * user_data_{nullptr};
-  std::mutex listener_callback_mutex_;
+  std::mutex on_new_request_m_;
   uint64_t unread_count_ = 0;
 };
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -84,13 +84,13 @@ public:
   void
   onNewDataMessage(eprosima::fastrtps::Subscriber * sub) final
   {
-    // Callback: add the subscription event to the event queue
-    std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+    update_unread_count(sub);
 
-    if(listener_callback_) {
-      listener_callback_(user_data_, 1);
+    std::unique_lock<std::mutex> lock_mutex(on_new_message_m_);
+
+    if(on_new_message_cb_) {
+      on_new_message_cb_(user_data_, 1);
     } else {
-      update_unread_count(sub);
       new_data_unread_count_++;
     }
   }
@@ -113,7 +113,7 @@ public:
   hasEvent(rmw_event_type_t event_type) const final;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
-  void eventSetExecutorCallback(
+  void set_on_new_event_callback(
     const void * user_data,
     rmw_event_callback_t callback) final;
 
@@ -169,11 +169,11 @@ public:
   // Provide handlers to perform an action when a
   // new event from this listener has ocurred
   void
-  subcriptionSetExecutorCallback(
+  set_on_new_message_callback(
     const void * user_data,
     rmw_event_callback_t callback)
   {
-    std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+    std::unique_lock<std::mutex> lock_mutex(on_new_message_m_);
 
     if (callback) {
       // Push events arrived before setting the executor's callback
@@ -182,10 +182,10 @@ public:
         new_data_unread_count_ = 0;
       }
       user_data_ = user_data;
-      listener_callback_ = callback;
+      on_new_message_cb_ = callback;
     } else {
       user_data_ = nullptr;
-      listener_callback_ = nullptr;
+      on_new_message_cb_ = nullptr;
     }
   }
 
@@ -207,6 +207,8 @@ private:
 
   std::set<eprosima::fastrtps::rtps::GUID_t> publishers_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
 
+  rmw_event_callback_t on_new_message_cb_{nullptr};
+  std::mutex on_new_message_m_;
   uint64_t new_data_unread_count_ = 0;
 };
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <limits>
 #include <mutex>
 #include <set>
 #include <utility>
@@ -54,13 +55,14 @@ struct CustomSubscriberInfo : public CustomEventInfo
 class SubListener : public EventListenerInterface, public eprosima::fastrtps::SubscriberListener
 {
 public:
-  explicit SubListener(CustomSubscriberInfo * info)
+  explicit SubListener(CustomSubscriberInfo * info, size_t qos_depth)
   : data_(0),
     deadline_changes_(false),
     liveliness_changes_(false),
     conditionMutex_(nullptr),
     conditionVariable_(nullptr)
   {
+    qos_depth_ = (qos_depth > 0) ? qos_depth : std::numeric_limits<size_t>::max();
     // Field is not used right now
     (void)info;
   }
@@ -178,7 +180,8 @@ public:
     if (callback) {
       // Push events arrived before setting the executor's callback
       if (new_data_unread_count_) {
-        callback(user_data, new_data_unread_count_);
+        auto unread_count = std::min(new_data_unread_count_, qos_depth_);
+        callback(user_data, unread_count);
         new_data_unread_count_ = 0;
       }
       user_data_ = user_data;
@@ -209,6 +212,7 @@ private:
 
   rmw_event_callback_t on_new_message_cb_{nullptr};
   std::mutex on_new_message_m_;
+  size_t qos_depth_;
   uint64_t new_data_unread_count_ = 0;
 };
 

--- a/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
@@ -39,11 +39,10 @@ PubListener::on_offered_deadline_missed(
 
   deadline_changes_.store(true, std::memory_order_relaxed);
 
-  // Callback: add the change in qos event to the event queue
-  std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+  std::unique_lock<std::mutex> lock_mutex(on_new_event_m_);
 
-  if(listener_callback_){
-    listener_callback_(user_data_, 1);
+  if(on_new_event_cb_){
+    on_new_event_cb_(user_data_, 1);
   } else {
     unread_events_count_++;
   }
@@ -66,11 +65,10 @@ void PubListener::on_liveliness_lost(
 
   liveliness_changes_.store(true, std::memory_order_relaxed);
 
-  // Callback: add the change in qos event to the event queue
-  std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+  std::unique_lock<std::mutex> lock_mutex(on_new_event_m_);
 
-  if(listener_callback_) {
-    listener_callback_(user_data_, 1);
+  if(on_new_event_cb_) {
+    on_new_event_cb_(user_data_, 1);
   } else {
     unread_events_count_++;
   }
@@ -90,11 +88,11 @@ bool PubListener::hasEvent(rmw_event_type_t event_type) const
   return false;
 }
 
-void PubListener::eventSetExecutorCallback(
+void PubListener::set_on_new_event_callback(
   const void * user_data,
   rmw_event_callback_t callback)
 {
-  std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+  std::unique_lock<std::mutex> lock_mutex(on_new_event_m_);
 
   if (callback) {
     // Push events arrived before setting the executor's callback
@@ -103,10 +101,10 @@ void PubListener::eventSetExecutorCallback(
       unread_events_count_ = 0;
     }
     user_data_ = user_data;
-    listener_callback_ = callback;
+    on_new_event_cb_ = callback;
   } else {
     user_data_ = nullptr;
-    listener_callback_ = nullptr;
+    on_new_event_cb_ = nullptr;
   }
 }
 

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -39,11 +39,10 @@ SubListener::on_requested_deadline_missed(
 
   deadline_changes_.store(true, std::memory_order_relaxed);
 
-  // Callback: add the subscription event to the event queue
-  std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+  std::unique_lock<std::mutex> lock_mutex(on_new_event_m_);
 
-  if(listener_callback_) {
-    listener_callback_(user_data_, 1);
+  if(on_new_event_cb_) {
+    on_new_event_cb_(user_data_, 1);
   } else {
     unread_events_count_++;
   }
@@ -68,11 +67,10 @@ void SubListener::on_liveliness_changed(
 
   liveliness_changes_.store(true, std::memory_order_relaxed);
 
-  // Callback: add the subscription event to the event queue
-  std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+  std::unique_lock<std::mutex> lock_mutex(on_new_event_m_);
 
-  if(listener_callback_) {
-    listener_callback_(user_data_, 1);
+  if(on_new_event_cb_) {
+    on_new_event_cb_(user_data_, 1);
   } else {
     unread_events_count_++;
   }
@@ -92,11 +90,11 @@ bool SubListener::hasEvent(rmw_event_type_t event_type) const
   return false;
 }
 
-void SubListener::eventSetExecutorCallback(
+void SubListener::set_on_new_event_callback(
   const void * user_data,
   rmw_event_callback_t callback)
 {
-  std::unique_lock<std::mutex> lock_mutex(listener_callback_mutex_);
+  std::unique_lock<std::mutex> lock_mutex(on_new_event_m_);
 
   if (callback) {
     // Push events arrived before setting the executor's callback
@@ -105,10 +103,10 @@ void SubListener::eventSetExecutorCallback(
       unread_events_count_ = 0;
     }
     user_data_ = user_data;
-    listener_callback_ = callback;
+    on_new_event_cb_ = callback;
   } else {
     user_data_ = nullptr;
-    listener_callback_ = nullptr;
+    on_new_event_cb_ = nullptr;
     return;
   }
 }

--- a/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
@@ -88,7 +88,7 @@ __rmw_client_set_on_new_response_callback(
   const void * user_data)
 {
   auto custom_client_info = static_cast<CustomClientInfo *>(rmw_client->data);
-  custom_client_info->listener_->clientSetExecutorCallback(
+  custom_client_info->listener_->set_on_new_response_callback(
     user_data,
     callback);
   return RMW_RET_OK;

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -75,7 +75,7 @@ __rmw_event_set_callback(
   const void * user_data)
 {
   auto custom_event_info = static_cast<CustomEventInfo *>(rmw_event->data);
-  custom_event_info->getListener()->eventSetExecutorCallback(
+  custom_event_info->getListener()->set_on_new_event_callback(
     user_data,
     callback);
   return RMW_RET_OK;

--- a/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
@@ -101,7 +101,7 @@ __rmw_service_set_on_new_request_callback(
   const void * user_data)
 {
   auto custom_service_info = static_cast<CustomServiceInfo *>(rmw_service->data);
-  custom_service_info->listener_->serviceSetExecutorCallback(
+  custom_service_info->listener_->set_on_new_request_callback(
     user_data,
     callback);
   return RMW_RET_OK;

--- a/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
@@ -114,7 +114,7 @@ __rmw_subscription_set_on_new_message_callback(
   const void * user_data)
 {
   auto custom_subscriber_info = static_cast<CustomSubscriberInfo *>(rmw_subscription->data);
-  custom_subscriber_info->listener_->subcriptionSetExecutorCallback(
+  custom_subscriber_info->listener_->set_on_new_message_callback(
     user_data,
     callback);
   return RMW_RET_OK;


### PR DESCRIPTION
* Rename apis
* Use `qos.depth` as limit to subscription "on_new_message_callback" `size_t` argument. 