### PR TITLE
Don't use FastDDS get_unread_count, it deadlocks.

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -90,11 +90,9 @@ public:
     std::unique_lock<std::mutex> lock_mutex(on_new_response_m_);
 
     if (on_new_response_cb_) {
-      auto unread_responses = get_unread_responses();
-
-      if (0 < unread_responses) {
-        on_new_response_cb_(user_data_, unread_responses);
-      }
+      on_new_response_cb_(user_data_, 1);
+    } else {
+      unread_responses_++;
     }
   }
 
@@ -130,10 +128,9 @@ public:
     std::unique_lock<std::mutex> lock_mutex(on_new_response_m_);
 
     if (callback) {
-      auto unread_responses = get_unread_responses();
-
-      if (0 < unread_responses) {
-        callback(user_data, unread_responses);
+      if (0 < unread_responses_) {
+        callback(user_data, unread_responses_);
+        unread_responses_ = 0;
       }
 
       user_data_ = user_data;
@@ -157,6 +154,7 @@ private:
 
   std::set<eprosima::fastrtps::rtps::GUID_t> publishers_;
 
+  size_t unread_responses_{0};
   rmw_event_callback_t on_new_response_cb_{nullptr};
 
   const void * user_data_{nullptr};

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -212,10 +212,10 @@ public:
   {
     std::unique_lock<std::mutex> lock_mutex(on_new_request_m_);
 
-    auto unread_requests = get_unread_resquests();
-
-    if (0u < unread_requests) {
-      on_new_request_cb_(user_data_, unread_requests);
+    if (on_new_request_cb_) {
+      on_new_request_cb_(user_data_, 1);
+    } else {
+      unread_requests_++;
     }
   }
 
@@ -229,10 +229,9 @@ public:
     std::unique_lock<std::mutex> lock_mutex(on_new_request_m_);
 
     if (callback) {
-      auto unread_requests = get_unread_resquests();
-
-      if (0 < unread_requests) {
-        callback(user_data, unread_requests);
+      if (0 < unread_requests_) {
+        callback(user_data, unread_requests_);
+        unread_requests_ = 0;
       }
 
       user_data_ = user_data;
@@ -257,7 +256,7 @@ private:
   rmw_event_callback_t on_new_request_cb_{nullptr};
 
   const void * user_data_{nullptr};
-
+  size_t unread_requests_{0};
   std::mutex on_new_request_m_;
 };
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -116,11 +116,9 @@ public:
     std::unique_lock<std::mutex> lock_mutex(on_new_message_m_);
 
     if (on_new_message_cb_) {
-      auto unread_messages = get_unread_messages();
-
-      if (0 < unread_messages) {
-        on_new_message_cb_(new_message_user_data_, unread_messages);
-      }
+      on_new_message_cb_(new_message_user_data_, 1);
+    } else {
+      unread_msgs_++;
     }
   }
 
@@ -210,6 +208,7 @@ private:
   std::set<eprosima::fastrtps::rtps::GUID_t> publishers_ RCPPUTILS_TSA_GUARDED_BY(
     discovery_m_);
 
+  size_t unread_msgs_{0};
   rmw_event_callback_t on_new_message_cb_{nullptr};
 
   const void * new_message_user_data_{nullptr};

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -217,10 +217,9 @@ SubListener::set_on_new_message_callback(
   std::unique_lock<std::mutex> lock_mutex(on_new_message_m_);
 
   if (callback) {
-    auto unread_messages = get_unread_messages();
-
-    if (0 < unread_messages) {
-      callback(user_data, unread_messages);
+    if (0 < unread_msgs_) {
+      callback(user_data, unread_msgs_);
+      unread_msgs_ = 0;
     }
 
     new_message_user_data_ = user_data;


### PR DESCRIPTION
This is a temporary fix. The real fix would come
from a modified eProsima/FastDDS

Signed-off-by: Mauro Passerino <mpasserino@irobot.com>